### PR TITLE
Fix bounds order in map.fitBounds call

### DIFF
--- a/fitsmap/cartographer.py
+++ b/fitsmap/cartographer.py
@@ -503,7 +503,7 @@ def build_index_js(
             "});",
             "",
             'if (urlParam("zoom")==null) {',
-            f"    map.fitBounds(L.latLngBounds([[0, 0], [{max_xy[0]}, {max_xy[1]}]]));",
+            f"    map.fitBounds(L.latLngBounds([[0, 0], [{max_xy[1]}, {max_xy[0]}]]));",
             "} else {",
             "    panFromUrl(map);",
             "}",


### PR DESCRIPTION
The initial map center seems wrong, possibly caused by the wrong x,y sequence.
Typically, the L.LatLng array is [latitude, longitude], which is[dec, ra].